### PR TITLE
MAINT: clean up the implementation of `fv`

### DIFF
--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -124,11 +124,28 @@ def fv(rate, nper, pmt, pv, when='end'):
 
     """
     when = _convert_when(when)
-    (rate, nper, pmt, pv, when) = map(np.asarray, [rate, nper, pmt, pv, when])
-    temp = (1+rate)**nper
-    fact = np.where(rate == 0, nper,
-                    (1 + rate*when)*(temp - 1)/rate)
-    return -(pv*temp + pmt*fact)
+    rate, nper, pmt, pv, when = np.broadcast_arrays(rate, nper, pmt, pv, when)
+
+    fv_array = np.empty_like(rate)
+    zero = rate == 0
+    nonzero = ~zero
+
+    fv_array[zero] = -(pv[zero] + pmt[zero] * nper[zero])
+
+    rate_nonzero = rate[nonzero]
+    nper_nonzero = nper[nonzero]
+    temp = (1 + rate_nonzero)**nper[nonzero]
+    fv_array[nonzero] = (
+        -pv[nonzero] * temp
+        - pmt[nonzero] * (1 + rate_nonzero * when[nonzero]) / rate_nonzero
+        * (temp - 1)
+    )
+
+    if np.ndim(fv_array) == 0:
+        # Follow the ufunc convention of returning scalars for scalar
+        # and 0d array inputs.
+        return fv_array.item(0)
+    return fv_array
 
 
 def pmt(rate, nper, pv, fv=0, when='end'):

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -133,10 +133,9 @@ def fv(rate, nper, pmt, pv, when='end'):
     fv_array[zero] = -(pv[zero] + pmt[zero] * nper[zero])
 
     rate_nonzero = rate[nonzero]
-    nper_nonzero = nper[nonzero]
     temp = (1 + rate_nonzero)**nper[nonzero]
     fv_array[nonzero] = (
-        -pv[nonzero] * temp
+        - pv[nonzero] * temp
         - pmt[nonzero] * (1 + rate_nonzero * when[nonzero]) / rate_nonzero
         * (temp - 1)
     )

--- a/numpy_financial/tests/test_financial.py
+++ b/numpy_financial/tests/test_financial.py
@@ -482,10 +482,7 @@ class TestFv:
     @pytest.mark.parametrize('when', [None, 0, 'end'])
     def test_when_is_end_float(self, when):
         args = (0.075, 20, -2000, 0)
-        if when is None:
-            result = npf.fv(*args)
-        else:
-            result = npf.fv(*args, when)
+        result = npf.fv(*args) if when is None else npf.fv(*args, when)
         assert_allclose(
             result,
             86609.362673,  # Computed using Google Sheet's FV
@@ -500,10 +497,7 @@ class TestFv:
             Decimal('-2000'),
             Decimal('0'),
         )
-        if when is None:
-            result = npf.fv(*args)
-        else:
-            result = npf.fv(*args, when)
+        result = npf.fv(*args) if when is None else npf.fv(*args, when)
         assert_almost_equal(result, Decimal('86609.362673'), decimal=5)
 
     def test_broadcast(self):


### PR DESCRIPTION
In particular, more clearly divide the rate-is-zero versus
rate-is-nonzero cases. Also organize the tests and add test cases for
broadcasting and zero rate.

I find implementing `fv` it this way much easier to understand, but if
others disagree I'm happy to drop it.