### PR TITLE
MAINT: small cleanups to `ipmt`

### DIFF
--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -417,21 +417,26 @@ def ipmt(rate, per, nper, pv, fv=0, when='end'):
                                                         pv, fv, when)
 
     total_pmt = pmt(rate, nper, pv, fv, when)
-    ipmt = np.array(_rbl(rate, per, total_pmt, pv, when) * rate)
+    ipmt_array = np.array(_rbl(rate, per, total_pmt, pv, when) * rate)
 
     # Payments start at the first period, so payments before that
     # don't make any sense.
-    ipmt[per < 1] = _value_like(ipmt, np.nan)
+    ipmt_array[per < 1] = _value_like(ipmt_array, np.nan)
     # If payments occur at the beginning of a period and this is the
     # first period, then no interest has accrued.
     per1_and_begin = (when == 1) & (per == 1)
-    ipmt[per1_and_begin] = _value_like(ipmt, 0)
+    ipmt_array[per1_and_begin] = _value_like(ipmt_array, 0)
     # If paying at the beginning we need to discount by one period.
     per_gt_1_and_begin = (when == 1) & (per > 1)
-    ipmt[per_gt_1_and_begin] = (
-        ipmt[per_gt_1_and_begin] / (1 + rate[per_gt_1_and_begin])
+    ipmt_array[per_gt_1_and_begin] = (
+        ipmt_array[per_gt_1_and_begin] / (1 + rate[per_gt_1_and_begin])
     )
-    return ipmt
+
+    if np.ndim(ipmt_array) == 0:
+        # Follow the ufunc convention of returning scalars for scalar
+        # and 0d array inputs.
+        return ipmt_array.item(0)
+    return ipmt_array
 
 
 def _rbl(rate, per, pmt, pv, when):


### PR DESCRIPTION
In particular,

- Avoid shadowing the function name with an `ipmt` variable inside the
  function
- Ensure that the function returns a scalar for 0d inputs; add
  regression tests
- Move some tests into the `TestIpmt` class that were missed in the
  previous refactoring