### PR TITLE
Add Initial Guess to IRR Function

### DIFF
--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -700,7 +700,7 @@ def _roots(p):
     return eigenvalues / p[0]
 
 
-def irr(values):
+def irr(values,guess=0):
     """
     Return the Internal Rate of Return (IRR).
 
@@ -781,7 +781,7 @@ def irr(values):
     # NPV(rate) = 0 can have more than one solution so we return
     # only the solution closest to zero.
     rate = 1/res - 1
-    rate = rate.item(np.argmin(np.abs(rate)))
+    rate = rate.item(np.argmin(np.abs(rate-guess)))
     return rate
 
 


### PR DESCRIPTION
ENH: Implemented the ability to add an initial guess to the irr function. 

This allows the user to guide how the final rate is chosen when more than one root is found, instead of simply choosing the value closest to zero.

This feature is related to the closed issue here: https://github.com/numpy/numpy-financial/issues/28.

For instance, the current formula returns -.76 for this cashflow: [-50, -100, 600, 300, -100]. This cashflow is quite attractive, and it is much more useful if the formula returned the other root value of 1.85. Adding the ability to have an initial guess would solve this problem.