### PR TITLE
ENH: Use Newton's method to calculate IRR

### DIFF
--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -700,7 +700,7 @@ def irr(values, guess=0.1):
     Notes
     -----
     The IRR is perhaps best understood through an example (illustrated
-    using np.irr in the Examples section below).  Suppose one invests 100
+    using np.irr in the Examples section below). Suppose one invests 100
     units and then makes the following withdrawals at regular (fixed)
     intervals: 39, 59, 55, 20.  Assuming the ending value is 0, one's 100
     unit investment yields 173 units; however, due to the combination of
@@ -741,23 +741,20 @@ def irr(values, guess=0.1):
     if values.ndim != 1:
         raise ValueError("Cashflows must be a rank-1 array")
 
-    solution_found = False
-    p = np.polynomial.Polynomial(values)
-    pp = p.deriv()
+    # NPV = V0 * (1+eirr)^0 + V1 * (1+eirr)^-1 + ...
+    #  let x = 1 / (1+eirr)
+    # NPV = V0 * x^0        + V1 * x^1         + ...
+    npv_ = np.polynomial.Polynomial(values)
+    d_npv = npv_.deriv()
     x = 1 / (1 + guess)
 
-    for i in range(100):
-        x_new = x - (p(x) / pp(x))
+    for _ in range(100):
+        x_new = x - (npv_(x) / d_npv(x))
         if abs(x_new - x) < 1e-12:
-            solution_found = True
-            break
+            return 1 / x_new - 1
         x = x_new
 
-    if solution_found:
-        return 1 / x - 1
-    else:
-        return np.nan
-
+    return np.nan
 
 
 def npv(rate, values):

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -741,6 +741,12 @@ def irr(values, guess=0.1):
     if values.ndim != 1:
         raise ValueError("Cashflows must be a rank-1 array")
 
+    # If all values are of the same sign no solution exists
+    # we don't perform any further calculations and exit early
+    same_sign = np.all(values > 0) if values[0] > 0 else np.all(values < 0)
+    if same_sign:
+        return np.nan
+
     # We aim to solve eirr such that NPV is exactly zero. This can be framed as
     # simply finding the closest root of a polynomial to a given initial guess
     # as follows:

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -690,7 +690,7 @@ def irr(values, guess=0.1):
         the initial investment, will typically be negative.
     guess : float, optional
         Initial guess of the IRR for the iterative solver. If no guess is
-        given 0.1 is used instead.
+        given an initial guess of 0.1 (i.e. 10%) is assumed instead.
 
     Returns
     -------

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -671,7 +671,7 @@ def rate(nper, pmt, pv, fv, when='end', guess=None, tol=None, maxiter=100):
         return rn
 
 
-def irr(values, guess=0.1):
+def irr(values, guess=0.1, tol=1e-12, maxiter=100):
     """
     Return the Internal Rate of Return (IRR).
 
@@ -691,6 +691,10 @@ def irr(values, guess=0.1):
     guess : float, optional
         Initial guess of the IRR for the iterative solver. If no guess is
         given an initial guess of 0.1 (i.e. 10%) is assumed instead.
+    tol : float, optional
+        Required tolerance to accept solution. Default is 1e-12.
+    maxiter : int, optional
+        Maximum iterations to perform in finding a solution. Default is 100.
 
     Returns
     -------
@@ -764,9 +768,9 @@ def irr(values, guess=0.1):
     d_npv = npv_.deriv()
     x = 1 / (1 + guess)
 
-    for _ in range(100):
+    for _ in range(maxiter):
         x_new = x - (npv_(x) / d_npv(x))
-        if abs(x_new - x) < 1e-12:
+        if abs(x_new - x) < tol:
             return 1 / x_new - 1
         x = x_new
 

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -741,9 +741,19 @@ def irr(values, guess=0.1):
     if values.ndim != 1:
         raise ValueError("Cashflows must be a rank-1 array")
 
-    # NPV = V0 * (1+eirr)^0 + V1 * (1+eirr)^-1 + ...
-    #  let x = 1 / (1+eirr)
-    # NPV = V0 * x^0        + V1 * x^1         + ...
+    # We aim to solve eirr such that NPV is exactly zero. This can be framed as
+    # simply finding the closest root of a polynomial to a given initial guess
+    # as follows:
+    #           V0           V1           V2           V3
+    # NPV = ---------- + ---------- + ---------- + ---------- + ...
+    #       (1+eirr)^0   (1+eirr)^1   (1+eirr)^2   (1+eirr)^3
+    #
+    # by letting x = 1 / (1+eirr), we substitute to get
+    #
+    # NPV = V0 * x^0   + V1 * x^1   +  V2 * x^2  +  V3 * x^3  + ...
+    # 
+    # which we solve using Newton-Raphson and then reverse out the solution 
+    # as eirr = 1/x - 1 (if we are close enough to a solution)
     npv_ = np.polynomial.Polynomial(values)
     d_npv = npv_.deriv()
     x = 1 / (1 + guess)

--- a/numpy_financial/tests/test_financial.py
+++ b/numpy_financial/tests/test_financial.py
@@ -580,9 +580,12 @@ class TestIrr:
             decimal=2,
         )
 
-    def test_numpy_gh_6744(self):
+    @pytest.mark.parametrize('v', [
+        (1, 2, 3),
+        (-1, -2, -3),
+    ])
+    def test_numpy_gh_6744(self, v):
         # Test that if there is no solution then npf.irr returns nan.
-        v = [-1, -2, -3]
         assert numpy.isnan(npf.irr(v))
 
     def test_gh_15(self):

--- a/numpy_financial/tests/test_financial.py
+++ b/numpy_financial/tests/test_financial.py
@@ -551,7 +551,7 @@ class TestFv:
 class TestIrr:
     def test_npv_irr_congruence(self):
         # IRR is defined as the rate required for the present value of
-        # a a series of cashflows to be zero, so we should have
+        # a series of cashflows to be zero, so we should have
         #
         # NPV(IRR(x), x) = 0.
         cashflows = numpy.array([-40000, 5000, 8000, 12000, 30000])


### PR DESCRIPTION
This PR uses Netwon's method to calculate the IRR instead of the existing eigenvalue approach.

The most significant difference is that now only the root closest to `guess` is found, not all of the roots. This means IRR no longer has to decided which root to return to the user. For large inputs this is significantly faster. On my system all tests pass but, so far, this is only a proof of concept and I'll still need to consider if there are any unforeseen changes.

@jamiecook - how does this look to you? It's using an initial guess, but, in this case, the guess serves a purpose as the initial solution in Newton's method.