### PR TITLE
ENH: Bump Python version to 3.6+

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
-        numpy-version: [1.15, 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        numpy-version: [1.15, 1.16, 1.17, 1.18, 1.19, "1.20", 1.21, 1.22]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
-        numpy-version: [1.15, 1.16, 1.17, 1.18, 1.19, "1.20", 1.21, 1.22]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        numpy-version: [1.15, 1.16, 1.17, 1.18, 1.19, 1.20, 1.21]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        numpy-version: [1.15, 1.16, 1.17, 1.18, 1.19, 1.20, 1.21]
+        numpy-version: [1.15, 1.16, 1.17, 1.18, 1.19]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
-        numpy-version: [1.15, 1.16, 1.17]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        numpy-version: [1.15, 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22]
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,11 @@ Intended Audience :: Financial and Insurance Industry
 License :: OSI Approved :: BSD License
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3 :: Only
 Topic :: Software Development
 Topic :: Office/Business :: Financial :: Accounting


### PR DESCRIPTION
This PR drops python 3.5 testing support and adds  support for future python and numpy versions