### PR TITLE
TEST: Drop python 3.5 tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7]
         numpy-version: [1.15, 1.16, 1.17]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ Intended Audience :: Financial and Insurance Industry
 License :: OSI Approved :: BSD License
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3 :: Only
@@ -56,7 +55,7 @@ if __name__ == "__main__":
           maintainer='Numpy Financial Developers',
           maintainer_email='numpy-discussion@python.org',
           install_requires=['numpy>=1.15'],
-          python_requires='>=3.5',
+          python_requires='>=3.6',
           classifiers=CLASSIFIERS.splitlines(),
           url='https://numpy.org/numpy-financial/',
           download_url='https://pypi.org/project/numpy-financial/',


### PR DESCRIPTION
https://github.com/numpy/numpy-financial/pull/49 fails because Python 3.5 is no longer supported by Github actions. This PR removes Python 3.5 from the tests. They are now only running with Python 3.6 and 3.7. 