### PR TITLE
ENH: Allow npv calculation to be broadcastable

### DIFF
--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -863,8 +863,15 @@ def npv(rate, values):
     3065.22267
 
     """
-    values = np.asarray(values)
-    return (values / (1+rate)**np.arange(0, len(values))).sum(axis=0)
+    values = np.atleast_2d(values)
+    timestep_array = np.arange(0, values.shape[1])
+    npv = (values / (1 + rate) ** timestep_array).sum(axis=1)
+    try:
+        # If size of array is one, return scalar
+        return npv.item()
+    except ValueError:
+        # Otherwise, return entire array
+        return npv
 
 
 def mirr(values, finance_rate, reinvest_rate):

--- a/numpy_financial/tests/test_financial.py
+++ b/numpy_financial/tests/test_financial.py
@@ -148,6 +148,19 @@ class TestNpv:
             npf.npv(Decimal('0.05'), [-15000, 1500, 2500, 3500, 4500, 6000]),
             Decimal('122.894854950942692161628715'))
 
+    def test_npv_broadcast(self):
+        cashflows = [
+            [-15000, 1500, 2500, 3500, 4500, 6000],
+            [-15000, 1500, 2500, 3500, 4500, 6000],
+            [-15000, 1500, 2500, 3500, 4500, 6000],
+            [-15000, 1500, 2500, 3500, 4500, 6000],
+        ]
+        expected_npvs = [
+            122.8948549, 122.8948549, 122.8948549, 122.8948549
+        ]
+        actual_npvs = npf.npv(0.05, cashflows)
+        assert_allclose(actual_npvs, expected_npvs)
+
 
 class TestPmt:
     def test_pmt_simple(self):


### PR DESCRIPTION
This PR applies broadcasting operations to ``npv`` calculations. This is significantly faster than iterating over an array of cashflows as is shown by the below code snippet.

```python
import numpy as np
from numpy.testing import assert_allclose
import numpy_financial as npf

import time


def faster_npv(rate: float, values: np.ndarray):
    """ A faster way to calculate NPV for several projects based
    on numpy arrays. """
    values = np.atleast_2d(values)
    timestep_array = np.arange(0, values.shape[1])
    npv = (values / (1 + rate) ** timestep_array).sum(axis=1)
    try:
        # If size of array is one, return scalar
        return npv.item()
    except ValueError:
        # Otherwise, return entire array
        return npv


if __name__ == "__main__":
    rate = 0.05
    no_simulations = int(1e6)
    lifetime = 10  # years

    capex = np.random.normal(loc=1000, scale=100, size=no_simulations)
    opex = np.random.normal(loc=100, scale=10, size=no_simulations)
    values = np.array([capex] + [opex] * lifetime).transpose()

    start_time = time.time()
    all_npv_slow = [npf.npv(rate, values[i]) for i in range(no_simulations)]
    print(f"Standard NPF calculations took {time.time() - start_time}s.")

    start_time = time.time()
    all_npv_fast = faster_npv(rate, values)
    print(f"Faster NPV calculations took {time.time() - start_time}s.")

    assert_allclose(all_npv_fast, all_npv_slow)
```
closes #52 