### PR TITLE
TST/MAINT: Update CI scirpts

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,10 +7,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", 'pypy2.7', 'pypy3.7', 'pypy3.8', 'pypy3.9']
 
     steps:
     - uses: actions/checkout@v3
@@ -35,4 +34,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest -v
+        pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
-        numpy-version: [1.15, 1.16, 1.17]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        numpy-version: ["1.20", "1.21", "1.22", "1.23"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        numpy-version: ["1.20", "1.21", "1.22", "1.23"]
 
     steps:
     - uses: actions/checkout@v3
@@ -21,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy==${{ matrix.numpy-version }}
+        pip install numpy
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,11 +5,12 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -34,4 +35,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        pytest -v

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", 'pypy3.7', 'pypy3.8', 'pypy3.9']
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        numpy-version: ["oldest-supported-numpy", "numpy"]
 
     steps:
     - uses: actions/checkout@v3
@@ -20,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy
+        pip install ${{ matrix.numpy-version }}
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,9 +13,9 @@ jobs:
         numpy-version: ["1.20", "1.21", "1.22", "1.23"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", 'pypy2.7', 'pypy3.7', 'pypy3.8', 'pypy3.9']
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", 'pypy3.7', 'pypy3.8', 'pypy3.9']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The test matrix was last updated in 2019. Using versions of NumPy and Python that have reached their end of life. This commit bumps the versions used to those that are still within their lifetime.