### PR TITLE
Avoid redundant computations in IRR calculation

### DIFF
--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -757,8 +757,9 @@ def irr(values, guess=None, tol=1e-12, maxiter=100):
 
     # If no value is passed for `guess`, then make a heuristic estimate
     if guess is None:
-        inflow = sum(x for x in values if x > 0)
-        outflow = -sum(x for x in values if x < 0)
+        positive_cashflow = values > 0
+        inflow = values.sum(where=positive_cashflow)
+        outflow = -values.sum(where=~positive_cashflow)
         guess = inflow / outflow - 1
 
     # We aim to solve eirr such that NPV is exactly zero. This can be framed as

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -773,10 +773,10 @@ def irr(values, guess=0.1, tol=1e-12, maxiter=100):
     x = 1 / (1 + guess)
 
     for _ in range(maxiter):
-        x_new = x - (npv_(x) / d_npv(x))
-        if abs(x_new - x) < tol:
-            return 1 / x_new - 1
-        x = x_new
+        delta = npv_(x) / d_npv(x)
+        if abs(delta) < tol:
+            return 1 / (x - delta) - 1
+        x -= delta
 
     return np.nan
 


### PR DESCRIPTION
The IRR computation adds and then subtract the previous iteration value before comparing to the tolerance. We can just compute the delta and compare that to the tolerance instead. This should also make the computation more robust if there is a large difference in magnitude between `x` and `delta`