### PR TITLE
Small addition to IRR function

### DIFF
--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -753,6 +753,9 @@ def irr(values, guess=None, tol=1e-12, maxiter=100):
     # we don't perform any further calculations and exit early
     same_sign = np.all(values > 0) if values[0] > 0 else np.all(values < 0)
     if same_sign:
+        print('No solution exists for IRR since all'
+              'cashflows are of the same sign. Returning'
+              'np.nan')
         return np.nan
 
     # If no value is passed for `guess`, then make a heuristic estimate

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -17,7 +17,8 @@ from decimal import Decimal
 import numpy as np
 
 __all__ = ['fv', 'pmt', 'nper', 'ipmt', 'ppmt', 'pv', 'rate',
-           'irr', 'npv', 'mirr']
+           'irr', 'npv', 'mirr',
+           'NoRealSolutionException', 'IterationsExceededException']
 
 _when_to_num = {'end': 0, 'begin': 1,
                 'e': 0, 'b': 1,

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -753,9 +753,9 @@ def irr(values, guess=None, tol=1e-12, maxiter=100):
     # we don't perform any further calculations and exit early
     same_sign = np.all(values > 0) if values[0] > 0 else np.all(values < 0)
     if same_sign:
-        print('No solution exists for IRR since all'
-              'cashflows are of the same sign. Returning'
-              'np.nan')
+        print('\nNo solution exists for IRR since all '
+              'cashflows are of the same sign. Returning '
+              'np.nan\n')
         return np.nan
 
     # If no value is passed for `guess`, then make a heuristic estimate

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -30,19 +30,13 @@ _when_to_num = {'end': 0, 'begin': 1,
 
 class NoRealSolutionException(Exception):
     """ No real solution to the problem. """
-    def __init__(self, message):
-        self.message = message
 
-    def __str__(self):
-        return self.message
+    pass
 
 class IterationsExceededException(Exception):
     """ Maximum number of iterations reached. """
-    def __init__(self, message):
-        self.message = message
 
-    def __str__(self):
-        return self.message
+    pass
 
 
 def _convert_when(when):


### PR DESCRIPTION
**Reference Issues/PRs**

None

**What does this implement?**

Small addition to the IRR function, such that it prints it is returning np.nan when all the cashflows are of the same sign. This will make the function more user intuitive, since the user will know why the function is returning nans and will make him check if the cashflows were properly calculated.

**Any other comment?**

Instead of a print, I'd use a warnings.warn, but for that the warnings package is needed, and I believe you want to minimize the requirements.txt
