### PR TITLE
Initial change to pydata_sphinx_theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,9 @@ Thumbs.db
 ##########################
 /.pytest_cache
 
+# Poetry lock file #
+####################
+poetry.lock
+
 # Things specific to this project #
 ###################################

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -32,7 +32,7 @@ author = 'numpy-financial developers'
 extensions = [
     'sphinx.ext.autodoc',
     'numpydoc',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,7 +20,7 @@ import numpy_financial
 # -- Project information -----------------------------------------------------
 
 project = 'numpy-financial'
-copyright = '2019, numpy-financial developers'
+copyright = '2023, numpy-financial developers'
 author = 'numpy-financial developers'
 
 
@@ -50,7 +50,7 @@ version = numpy_financial.__version__
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'bizstyle'
+html_theme = 'pydata_sphinx_theme'
 html_copy_source = False
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pytest = "^7.4"
 [tool.poetry.group.docs.dependencies]
 sphinx = "^7.0"
 numpydoc = "^1.5"
+pydata-sphinx-theme = "^0.14.3"
 
 
 [tool.poetry.group.lint.dependencies]


### PR DESCRIPTION
This applies the pydata_sphinx_theme theme to NumPy Financial. The theme builds and the documentation is rendered _almost_ correctly, except that LaTeX is rendered to the far right of the page.