### PR TITLE
TST: Make linting own step in CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+      - push
+      - pull_request
 
 permissions:
    contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+   contents: read  # to fetch code (actions/checkout)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test_lint:
+    name: Lint
+    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python packages
+      run: |
+        python -m pip install --upgrade pip poetry
+        poetry env use ${{ matrix.python-version }}
+        poetry install --with=test --with=lint
+
+    - name: Lint with flake8
+      run: |
+        set -euo pipefail
+        # stop the build if there are Python syntax errors or undefined names
+        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # The GitHub editor is 127 chars wide
+        poetry run flake8 . --ignore=F401,F403,W503,E226 --count --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
   test_lint:
     name: Lint
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    if: "github.repository == 'numpy/numpy-financial' || github.repository == ''"
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,12 @@
 name: Lint
 
 on:
+  push:
+    branches:
+      - "*"
   pull_request:
     branches:
       - main
-      - push
-      - pull_request
 
 permissions:
    contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,13 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip poetry
         poetry env use ${{ matrix.python-version }}
-        poetry install --with=test --with=lint
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # The GitHub editor is 127 chars wide
-        poetry run flake8 . --ignore=F401,F403,W503,E226 --count --max-complexity=10 --max-line-length=127 --statistics
+        poetry install --with=test
     - name: Test with pytest
       run: |
         poetry run pytest


### PR DESCRIPTION
This removes the redundancy of running the linting for each combination of OS/Python version