### PR TITLE
ENH: Proof of Concept: Move NPV to Numba

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,39 +1,34 @@
+from decimal import Decimal
+
 import numpy as np
 import numpy_financial as npf
 
 
-class Npv1DCashflow:
-
-    param_names = ["cashflow_length"]
-    params = [
-        (1, 10, 100, 1000),
-    ]
-
-    def __init__(self):
-        self.cashflows = None
-
-    def setup(self, cashflow_length):
-        rng = np.random.default_rng(0)
-        self.cashflows = rng.standard_normal(cashflow_length)
-
-    def time_1d_cashflow(self, cashflow_length):
-        npf.npv(0.08, self.cashflows)
-
-
 class Npv2DCashflows:
 
-    param_names = ["n_cashflows", "cashflow_lengths"]
+    param_names = ["n_cashflows", "cashflow_lengths", "rates_lengths"]
     params = [
+        (1, 10, 100, 1000),
         (1, 10, 100, 1000),
         (1, 10, 100, 1000),
     ]
 
     def __init__(self):
+        self.rates_decimal = None
+        self.rates = None
+        self.cashflows_decimal = None
         self.cashflows = None
 
-    def setup(self, n_cashflows, cashflow_lengths):
+    def setup(self, n_cashflows, cashflow_lengths, rates_lengths):
         rng = np.random.default_rng(0)
-        self.cashflows = rng.standard_normal((n_cashflows, cashflow_lengths))
+        cf_shape = (n_cashflows, cashflow_lengths)
+        self.cashflows = rng.standard_normal(cf_shape)
+        self.rates = rng.standard_normal(rates_lengths)
+        self.cashflows_decimal = rng.standard_normal(cf_shape, dtype=Decimal)
+        self.rates_decimal = rng.standard_normal(rates_lengths, dtype=Decimal)
 
-    def time_2d_cashflow(self, n_cashflows, cashflow_lengths):
-        npf.npv(0.08, self.cashflows)
+    def time_2d_cashflow(self, n_cashflows, cashflow_lengths, rates_lengths):
+        npf.npv(self.rates, self.cashflows)
+
+    def time_2d_cashflow_decimal(self, n_cashflows, cashflow_lengths, rates_lengths):
+        npf.npv(self.rates_decimal, self.cashflows_decimal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ packages = [{include = "numpy_financial"}]
 [tool.poetry.dependencies]
 python = "^3.9"
 numpy = "^1.23"
+numba = "^0.58.1"
 
 
 [tool.poetry.group.test.dependencies]

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -186,21 +186,26 @@ class TestNpv:
         actual_npvs = npf.npv(0.05, cashflows)
         assert_allclose(actual_npvs, expected_npvs)
 
-    def test_npv_broadcast_equals_for_loop(self):
-        cashflows = np.array([
-            [-15000.0, 1500.0, 2500.0, 3500.0, 4500.0, 6000.0],
-            [-25000.0, 1500.0, 2500.0, 3500.0, 4500.0, 6000.0],
-            [-35000.0, 1500.0, 2500.0, 3500.0, 4500.0, 6000.0],
-            [-45000.0, 1500.0, 2500.0, 3500.0, 4500.0, 6000.0],
-        ])
-        rates = np.array([-0.05, 0.00, 0.05, 0.10, 0.15])
+    @pytest.mark.parametrize("dtype", [Decimal, float])
+    def test_npv_broadcast_equals_for_loop(self, dtype):
+        cashflows_str = [
+            ["-15000.0", "1500.0", "2500.0", "3500.0", "4500.0", "6000.0"],
+            ["-25000.0", "1500.0", "2500.0", "3500.0", "4500.0", "6000.0"],
+            ["-35000.0", "1500.0", "2500.0", "3500.0", "4500.0", "6000.0"],
+            ["-45000.0", "1500.0", "2500.0", "3500.0", "4500.0", "6000.0"],
+        ]
+        rates_str = ["-0.05", "0.00", "0.05", "0.10", "0.15"]
 
-        res = np.empty((len(rates), len(cashflows)))
+        cashflows = np.array([[dtype(x) for x in cf] for cf in cashflows_str])
+        rates = np.array([dtype(x) for x in rates_str])
+
+        expected = np.empty((len(rates), len(cashflows)), dtype=dtype)
         for i, r in enumerate(rates):
             for j, cf in enumerate(cashflows):
-                res[i, j] = npf.npv(r, cf).item()
+                expected[i, j] = npf.npv(r, cf).item()
 
-        assert_allclose(npf.npv(rates, cashflows), res)
+        actual = npf.npv(rates, cashflows)
+        assert_equal(actual, expected)
 
 
 class TestPmt:


### PR DESCRIPTION
This PR moves the Net Present Value function to Numba

It is still a WIP, I'm not sure if the design decisions I've made are correct. Feedback is welcome.

I've tried using ``numba.guvectorize`` to make gufuncs out of the NumPy-Financial functions. This didn't work well (because we're not using "proper" gufuncs. Instead I've written them as for loops that are spead up with numba's `jit`/`njit` functions. 

This leads to some duplication as we need both a ``jit`` and ``njit`` decorator to support ``decimal.Decimal`` (which is a PyObject).

Note that Numba does not support Python3.12 yet, this is expected to be out soon (in the 0.59 release) see the [tracking issue](https://github.com/numba/numba/issues/9197) for more details 