### PR TITLE
Remove assert_almost_equals from tests

### DIFF
--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -14,86 +14,140 @@ from numpy.testing import (
 
 import numpy_financial as npf
 
-def assert_decimal_close(actual, expected, tol=Decimal('1e-7')):
+
+def assert_decimal_close(actual, expected, tol=Decimal("1e-7")):
     # Check if both actual and expected are iterable (like arrays)
-    if hasattr(actual, '__iter__') and hasattr(expected, '__iter__'):
+    if hasattr(actual, "__iter__") and hasattr(expected, "__iter__"):
         for a, e in zip(actual, expected):
             assert abs(a - e) <= tol
     else:
         # For single value comparisons
         assert abs(actual - expected) <= tol
 
+
 class TestFinancial(object):
     def test_when(self):
         # begin
-        assert_equal(npf.rate(10, 20, -3500, 10000, 1),
-                     npf.rate(10, 20, -3500, 10000, 'begin'))
+        assert_equal(
+            npf.rate(10, 20, -3500, 10000, 1), npf.rate(10, 20, -3500, 10000, "begin")
+        )
         # end
-        assert_equal(npf.rate(10, 20, -3500, 10000),
-                     npf.rate(10, 20, -3500, 10000, 'end'))
-        assert_equal(npf.rate(10, 20, -3500, 10000, 0),
-                     npf.rate(10, 20, -3500, 10000, 'end'))
+        assert_equal(
+            npf.rate(10, 20, -3500, 10000), npf.rate(10, 20, -3500, 10000, "end")
+        )
+        assert_equal(
+            npf.rate(10, 20, -3500, 10000, 0), npf.rate(10, 20, -3500, 10000, "end")
+        )
 
         # begin
-        assert_equal(npf.pv(0.07, 20, 12000, 0, 1),
-                     npf.pv(0.07, 20, 12000, 0, 'begin'))
+        assert_equal(npf.pv(0.07, 20, 12000, 0, 1), npf.pv(0.07, 20, 12000, 0, "begin"))
         # end
-        assert_equal(npf.pv(0.07, 20, 12000, 0),
-                     npf.pv(0.07, 20, 12000, 0, 'end'))
-        assert_equal(npf.pv(0.07, 20, 12000, 0, 0),
-                     npf.pv(0.07, 20, 12000, 0, 'end'))
+        assert_equal(npf.pv(0.07, 20, 12000, 0), npf.pv(0.07, 20, 12000, 0, "end"))
+        assert_equal(npf.pv(0.07, 20, 12000, 0, 0), npf.pv(0.07, 20, 12000, 0, "end"))
 
         # begin
-        assert_equal(npf.pmt(0.08 / 12, 5 * 12, 15000., 0, 1),
-                     npf.pmt(0.08 / 12, 5 * 12, 15000., 0, 'begin'))
+        assert_equal(
+            npf.pmt(0.08 / 12, 5 * 12, 15000.0, 0, 1),
+            npf.pmt(0.08 / 12, 5 * 12, 15000.0, 0, "begin"),
+        )
         # end
-        assert_equal(npf.pmt(0.08 / 12, 5 * 12, 15000., 0),
-                     npf.pmt(0.08 / 12, 5 * 12, 15000., 0, 'end'))
-        assert_equal(npf.pmt(0.08 / 12, 5 * 12, 15000., 0, 0),
-                     npf.pmt(0.08 / 12, 5 * 12, 15000., 0, 'end'))
+        assert_equal(
+            npf.pmt(0.08 / 12, 5 * 12, 15000.0, 0),
+            npf.pmt(0.08 / 12, 5 * 12, 15000.0, 0, "end"),
+        )
+        assert_equal(
+            npf.pmt(0.08 / 12, 5 * 12, 15000.0, 0, 0),
+            npf.pmt(0.08 / 12, 5 * 12, 15000.0, 0, "end"),
+        )
 
         # begin
-        assert_equal(npf.nper(0.075, -2000, 0, 100000., 1),
-                     npf.nper(0.075, -2000, 0, 100000., 'begin'))
+        assert_equal(
+            npf.nper(0.075, -2000, 0, 100000.0, 1),
+            npf.nper(0.075, -2000, 0, 100000.0, "begin"),
+        )
         # end
-        assert_equal(npf.nper(0.075, -2000, 0, 100000.),
-                     npf.nper(0.075, -2000, 0, 100000., 'end'))
-        assert_equal(npf.nper(0.075, -2000, 0, 100000., 0),
-                     npf.nper(0.075, -2000, 0, 100000., 'end'))
+        assert_equal(
+            npf.nper(0.075, -2000, 0, 100000.0),
+            npf.nper(0.075, -2000, 0, 100000.0, "end"),
+        )
+        assert_equal(
+            npf.nper(0.075, -2000, 0, 100000.0, 0),
+            npf.nper(0.075, -2000, 0, 100000.0, "end"),
+        )
 
     def test_decimal_with_when(self):
         """
         Test that decimals are still supported if the when argument is passed
         """
         # begin
-        assert_equal(npf.rate(Decimal('10'), Decimal('20'), Decimal('-3500'),
-                              Decimal('10000'), Decimal('1')),
-                     npf.rate(Decimal('10'), Decimal('20'), Decimal('-3500'),
-                              Decimal('10000'), 'begin'))
+        assert_equal(
+            npf.rate(
+                Decimal("10"),
+                Decimal("20"),
+                Decimal("-3500"),
+                Decimal("10000"),
+                Decimal("1"),
+            ),
+            npf.rate(
+                Decimal("10"),
+                Decimal("20"),
+                Decimal("-3500"),
+                Decimal("10000"),
+                "begin",
+            ),
+        )
         # end
-        assert_equal(npf.rate(Decimal('10'), Decimal('20'), Decimal('-3500'),
-                              Decimal('10000')),
-                     npf.rate(Decimal('10'), Decimal('20'), Decimal('-3500'),
-                              Decimal('10000'), 'end'))
-        assert_equal(npf.rate(Decimal('10'), Decimal('20'), Decimal('-3500'),
-                              Decimal('10000'), Decimal('0')),
-                     npf.rate(Decimal('10'), Decimal('20'), Decimal('-3500'),
-                              Decimal('10000'), 'end'))
+        assert_equal(
+            npf.rate(Decimal("10"), Decimal("20"), Decimal("-3500"), Decimal("10000")),
+            npf.rate(
+                Decimal("10"), Decimal("20"), Decimal("-3500"), Decimal("10000"), "end"
+            ),
+        )
+        assert_equal(
+            npf.rate(
+                Decimal("10"),
+                Decimal("20"),
+                Decimal("-3500"),
+                Decimal("10000"),
+                Decimal("0"),
+            ),
+            npf.rate(
+                Decimal("10"), Decimal("20"), Decimal("-3500"), Decimal("10000"), "end"
+            ),
+        )
 
         # begin
-        assert_equal(npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
-                            Decimal('0'), Decimal('1')),
-                     npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
-                            Decimal('0'), 'begin'))
+        assert_equal(
+            npf.pv(
+                Decimal("0.07"),
+                Decimal("20"),
+                Decimal("12000"),
+                Decimal("0"),
+                Decimal("1"),
+            ),
+            npf.pv(
+                Decimal("0.07"), Decimal("20"), Decimal("12000"), Decimal("0"), "begin"
+            ),
+        )
         # end
-        assert_equal(npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
-                            Decimal('0')),
-                     npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
-                            Decimal('0'), 'end'))
-        assert_equal(npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
-                            Decimal('0'), Decimal('0')),
-                     npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
-                            Decimal('0'), 'end'))
+        assert_equal(
+            npf.pv(Decimal("0.07"), Decimal("20"), Decimal("12000"), Decimal("0")),
+            npf.pv(
+                Decimal("0.07"), Decimal("20"), Decimal("12000"), Decimal("0"), "end"
+            ),
+        )
+        assert_equal(
+            npf.pv(
+                Decimal("0.07"),
+                Decimal("20"),
+                Decimal("12000"),
+                Decimal("0"),
+                Decimal("0"),
+            ),
+            npf.pv(
+                Decimal("0.07"), Decimal("20"), Decimal("12000"), Decimal("0"), "end"
+            ),
+        )
 
 
 class TestPV:
@@ -101,17 +155,18 @@ class TestPV:
         assert_allclose(npf.pv(0.07, 20, 12000, 0), -127128.17, atol=1e-2)
 
     def test_pv_decimal(self):
-        assert_equal(npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
-                            Decimal('0')),
-                     Decimal('-127128.1709461939327295222005'))
+        assert_equal(
+            npf.pv(Decimal("0.07"), Decimal("20"), Decimal("12000"), Decimal("0")),
+            Decimal("-127128.1709461939327295222005"),
+        )
 
 
 class TestRate:
     def test_rate(self):
         assert_allclose(npf.rate(10, 0, -3500, 10000), 0.1107, atol=1e-4)
 
-    @pytest.mark.parametrize('number_type', [Decimal, float])
-    @pytest.mark.parametrize('when', [0, 1, 'end', 'begin'])
+    @pytest.mark.parametrize("number_type", [Decimal, float])
+    @pytest.mark.parametrize("when", [0, 1, "end", "begin"])
     def test_rate_with_infeasible_solution(self, number_type, when):
         """
         Test when no feasible rate can be found.
@@ -121,18 +176,19 @@ class TestRate:
         This can occur if both `pmt` and `pv` have the same sign, as it is
         impossible to repay a loan by making further withdrawls.
         """
-        result = npf.rate(number_type(12.0),
-                          number_type(400.0),
-                          number_type(10000.0),
-                          number_type(5000.0),
-                          when=when)
+        result = npf.rate(
+            number_type(12.0),
+            number_type(400.0),
+            number_type(10000.0),
+            number_type(5000.0),
+            when=when,
+        )
         is_nan = Decimal.is_nan if number_type == Decimal else numpy.isnan
         assert is_nan(result)
 
     def test_rate_decimal(self):
-        rate = npf.rate(Decimal('10'), Decimal('0'), Decimal('-3500'),
-                        Decimal('10000'))
-        assert_equal(Decimal('0.1106908537142689284704528100'), rate)
+        rate = npf.rate(Decimal("10"), Decimal("0"), Decimal("-3500"), Decimal("10000"))
+        assert_equal(Decimal("0.1106908537142689284704528100"), rate)
 
     def test_gh48(self):
         """
@@ -151,9 +207,15 @@ class TestRate:
         # Test that if the maximum number of iterations is reached,
         # then npf.rate returns IterationsExceededException
         # when raise_exceptions is set to True.
-        assert_raises(npf.IterationsExceededError, npf.rate, Decimal(12.0),
-                      Decimal(400.0), Decimal(10000.0), Decimal(5000.0),
-                      raise_exceptions=True)
+        assert_raises(
+            npf.IterationsExceededError,
+            npf.rate,
+            Decimal(12.0),
+            Decimal(400.0),
+            Decimal(10000.0),
+            Decimal(5000.0),
+            raise_exceptions=True,
+        )
 
     def test_rate_maximum_iterations_exception_array(self):
         # Test that if the maximum number of iterations is reached in at least
@@ -163,21 +225,28 @@ class TestRate:
         pmt = 0
         pv = [-593.06, -4725.38, -662.05, -428.78, -13.65]
         fv = [214.07, 4509.97, 224.11, 686.29, -329.67]
-        assert_raises(npf.IterationsExceededError, npf.rate, nper,
-                      pmt, pv, fv,
-                      raise_exceptions=True)
+        assert_raises(
+            npf.IterationsExceededError,
+            npf.rate,
+            nper,
+            pmt,
+            pv,
+            fv,
+            raise_exceptions=True,
+        )
 
 
 class TestNpv:
     def test_npv(self):
         assert_allclose(
-            npf.npv(0.05, [-15000, 1500, 2500, 3500, 4500, 6000]),
-            122.89, atol=1e-2)
+            npf.npv(0.05, [-15000, 1500, 2500, 3500, 4500, 6000]), 122.89, atol=1e-2
+        )
 
     def test_npv_decimal(self):
         assert_equal(
-            npf.npv(Decimal('0.05'), [-15000, 1500, 2500, 3500, 4500, 6000]),
-            Decimal('122.894854950942692161628715'))
+            npf.npv(Decimal("0.05"), [-15000, 1500, 2500, 3500, 4500, 6000]),
+            Decimal("122.894854950942692161628715"),
+        )
 
     def test_npv_broadcast(self):
         cashflows = [
@@ -186,9 +255,7 @@ class TestNpv:
             [-15000, 1500, 2500, 3500, 4500, 6000],
             [-15000, 1500, 2500, 3500, 4500, 6000],
         ]
-        expected_npvs = [
-            122.8948549, 122.8948549, 122.8948549, 122.8948549
-        ]
+        expected_npvs = [122.8948549, 122.8948549, 122.8948549, 122.8948549]
         actual_npvs = npf.npv(0.05, cashflows)
         assert_allclose(actual_npvs, expected_npvs)
 
@@ -213,27 +280,36 @@ class TestPmt:
         assert_allclose(res, tgt)
 
     def test_pmt_decimal_simple(self):
-        res = npf.pmt(Decimal('0.08') / Decimal('12'), 5 * 12, 15000)
-        tgt = Decimal('-304.1459143262052370338701494')
+        res = npf.pmt(Decimal("0.08") / Decimal("12"), 5 * 12, 15000)
+        tgt = Decimal("-304.1459143262052370338701494")
         assert_equal(res, tgt)
 
     def test_pmt_decimal_zero_rate(self):
         # Test the edge case where rate == 0.0
-        res = npf.pmt(Decimal('0'), Decimal('60'), Decimal('15000'))
+        res = npf.pmt(Decimal("0"), Decimal("60"), Decimal("15000"))
         tgt = -250
         assert_equal(res, tgt)
 
     def test_pmt_decimal_broadcast(self):
         # Test the case where we use broadcast and
         # the arguments passed in are arrays.
-        res = npf.pmt([[Decimal('0'), Decimal('0.8')],
-                       [Decimal('0.3'), Decimal('0.8')]],
-                      [Decimal('12'), Decimal('3')],
-                      [Decimal('2000'), Decimal('20000')])
-        tgt = numpy.array([[Decimal('-166.6666666666666666666666667'),
-                            Decimal('-19311.25827814569536423841060')],
-                           [Decimal('-626.9081401700757748402586600'),
-                            Decimal('-19311.25827814569536423841060')]])
+        res = npf.pmt(
+            [[Decimal("0"), Decimal("0.8")], [Decimal("0.3"), Decimal("0.8")]],
+            [Decimal("12"), Decimal("3")],
+            [Decimal("2000"), Decimal("20000")],
+        )
+        tgt = numpy.array(
+            [
+                [
+                    Decimal("-166.6666666666666666666666667"),
+                    Decimal("-19311.25827814569536423841060"),
+                ],
+                [
+                    Decimal("-626.9081401700757748402586600"),
+                    Decimal("-19311.25827814569536423841060"),
+                ],
+            ]
+        )
 
         # Cannot use the `assert_allclose` because it uses isfinite under
         # the covers which does not support the Decimal type
@@ -245,56 +321,89 @@ class TestPmt:
 
 
 class TestMirr:
-    @pytest.mark.parametrize("values,finance_rate,reinvest_rate,expected", [
-        ([-4500, -800, 800, 800, 600, 600, 800, 800, 700, 3000], 0.08, 0.055, 0.0666),
-        ([-120000, 39000, 30000, 21000, 37000, 46000], 0.10, 0.12, 0.126094),
-        ([100, 200, -50, 300, -200], 0.05, 0.06, 0.3428),
-        ([39000, 30000, 21000, 37000, 46000], 0.10, 0.12, None)
-    ])
+    @pytest.mark.parametrize(
+        "values,finance_rate,reinvest_rate,expected",
+        [
+            (
+                [-4500, -800, 800, 800, 600, 600, 800, 800, 700, 3000],
+                0.08,
+                0.055,
+                0.0666,
+            ),
+            ([-120000, 39000, 30000, 21000, 37000, 46000], 0.10, 0.12, 0.126094),
+            ([100, 200, -50, 300, -200], 0.05, 0.06, 0.3428),
+            ([39000, 30000, 21000, 37000, 46000], 0.10, 0.12, None),
+        ],
+    )
     def test_mirr(self, values, finance_rate, reinvest_rate, expected):
         result = npf.mirr(values, finance_rate, reinvest_rate)
 
         if expected:
-            decimal_part_len = len(str(expected).split('.')[1])
-            atol_value = 10 ** -decimal_part_len
+            decimal_part_len = len(str(expected).split(".")[1])
+            atol_value = 10**-decimal_part_len
             assert_allclose(result, expected, atol=atol_value)
         else:
             assert_(numpy.isnan(result))
 
-    @pytest.mark.parametrize('number_type', [Decimal, float])
+    @pytest.mark.parametrize("number_type", [Decimal, float])
     @pytest.mark.parametrize(
         "args, expected",
         [
-            ({'values': [
-                '-4500', '-800', '800', '800', '600', '600', '800', '800', '700', '3000'
-            ],
-              'finance_rate': '0.08', 'reinvest_rate': '0.055'
-              }, '0.066597175031553548874239618'
-             ),
-            ({'values': ['-120000', '39000', '30000', '21000', '37000', '46000'],
-              'finance_rate': '0.10', 'reinvest_rate': '0.12'
-              }, '0.126094130365905145828421880'
-             ),
-            ({'values': ['100', '200', '-50', '300', '-200'],
-              'finance_rate': '0.05', 'reinvest_rate': '0.06'
-              }, '0.342823387842176663647819868'
-             ),
-            ({'values': ['39000', '30000', '21000', '37000', '46000'],
-              'finance_rate': '0.10', 'reinvest_rate': '0.12'
-              }, numpy.nan
-             ),
+            (
+                {
+                    "values": [
+                        "-4500",
+                        "-800",
+                        "800",
+                        "800",
+                        "600",
+                        "600",
+                        "800",
+                        "800",
+                        "700",
+                        "3000",
+                    ],
+                    "finance_rate": "0.08",
+                    "reinvest_rate": "0.055",
+                },
+                "0.066597175031553548874239618",
+            ),
+            (
+                {
+                    "values": ["-120000", "39000", "30000", "21000", "37000", "46000"],
+                    "finance_rate": "0.10",
+                    "reinvest_rate": "0.12",
+                },
+                "0.126094130365905145828421880",
+            ),
+            (
+                {
+                    "values": ["100", "200", "-50", "300", "-200"],
+                    "finance_rate": "0.05",
+                    "reinvest_rate": "0.06",
+                },
+                "0.342823387842176663647819868",
+            ),
+            (
+                {
+                    "values": ["39000", "30000", "21000", "37000", "46000"],
+                    "finance_rate": "0.10",
+                    "reinvest_rate": "0.12",
+                },
+                numpy.nan,
+            ),
         ],
     )
     def test_mirr_decimal(self, number_type, args, expected):
-        values = [number_type(v) for v in args['values']]
+        values = [number_type(v) for v in args["values"]]
         result = npf.mirr(
             values,
-            number_type(args['finance_rate']),
-            number_type(args['reinvest_rate'])
+            number_type(args["finance_rate"]),
+            number_type(args["reinvest_rate"]),
         )
 
         if expected is not numpy.nan:
-            assert_decimal_close(result, number_type(expected), 1e-15) #np.infinite()
+            assert_decimal_close(result, number_type(expected), 1e-15)  # np.infinite()
         else:
             assert numpy.isnan(result)
 
@@ -317,14 +426,14 @@ class TestNper:
         )
 
     def test_gh_18(self):
-        with numpy.errstate(divide='raise'):
+        with numpy.errstate(divide="raise"):
             assert_allclose(
                 npf.nper(0.1, 0, -500, 1500),
                 11.52670461,  # Computed using Google Sheet's NPER
             )
 
     def test_infinite_payments(self):
-        with numpy.errstate(divide='raise'):
+        with numpy.errstate(divide="raise"):
             result = npf.nper(0, -0.0, 1000)
         assert_(result == numpy.inf)
 
@@ -332,31 +441,30 @@ class TestNper:
         assert_(npf.nper(0, -100, 1000) == 10)
 
     def test_broadcast(self):
-        assert_allclose(npf.nper(0.075, -2000, 0, 100000., [0, 1]),
-                            [21.5449442, 20.76156441], atol=1e-4)
+        assert_allclose(
+            npf.nper(0.075, -2000, 0, 100000.0, [0, 1]),
+            [21.5449442, 20.76156441],
+            atol=1e-4,
+        )
 
 
 class TestPpmt:
     def test_float(self):
-        assert_allclose(
-            npf.ppmt(0.1 / 12, 1, 60, 55000),
-            -710.25,
-            rtol=1e-4
-        )
+        assert_allclose(npf.ppmt(0.1 / 12, 1, 60, 55000), -710.25, rtol=1e-4)
 
     def test_decimal(self):
         result = npf.ppmt(
-            Decimal('0.1') / Decimal('12'),
-            Decimal('1'),
-            Decimal('60'),
-            Decimal('55000')
+            Decimal("0.1") / Decimal("12"),
+            Decimal("1"),
+            Decimal("60"),
+            Decimal("55000"),
         )
         assert_equal(
             result,
-            Decimal('-710.2541257864217612489830917'),
+            Decimal("-710.2541257864217612489830917"),
         )
 
-    @pytest.mark.parametrize('when', [1, 'begin'])
+    @pytest.mark.parametrize("when", [1, "begin"])
     def test_when_is_begin(self, when):
         assert_allclose(
             npf.ppmt(0.1 / 12, 1, 60, 55000, 0, when),
@@ -364,7 +472,7 @@ class TestPpmt:
             rtol=1e-9,
         )
 
-    @pytest.mark.parametrize('when', [None, 0, 'end'])
+    @pytest.mark.parametrize("when", [None, 0, "end"])
     def test_when_is_end(self, when):
         args = (0.1 / 12, 1, 60, 55000, 0)
         result = npf.ppmt(*args) if when is None else npf.ppmt(*args, when)
@@ -374,86 +482,97 @@ class TestPpmt:
             rtol=1e-9,
         )
 
-    @pytest.mark.parametrize('when', [Decimal('1'), 'begin'])
+    @pytest.mark.parametrize("when", [Decimal("1"), "begin"])
     def test_when_is_begin_decimal(self, when):
         result = npf.ppmt(
-            Decimal('0.08') / Decimal('12'),
-            Decimal('1'),
-            Decimal('60'),
-            Decimal('15000.'),
-            Decimal('0'),
-            when
+            Decimal("0.08") / Decimal("12"),
+            Decimal("1"),
+            Decimal("60"),
+            Decimal("15000."),
+            Decimal("0"),
+            when,
         )
         assert_decimal_close(
             result,
-            Decimal('-302.131703'),  # Computed using Google Sheet's PPMT
+            Decimal("-302.131703"),  # Computed using Google Sheet's PPMT
             tol=1e-5,
         )
 
-    @pytest.mark.parametrize('when', [None, Decimal('0'), 'end'])
+    @pytest.mark.parametrize("when", [None, Decimal("0"), "end"])
     def test_when_is_end_decimal(self, when):
         args = (
-            Decimal('0.08') / Decimal('12'),
-            Decimal('1'),
-            Decimal('60'),
-            Decimal('15000.'),
-            Decimal('0')
+            Decimal("0.08") / Decimal("12"),
+            Decimal("1"),
+            Decimal("60"),
+            Decimal("15000."),
+            Decimal("0"),
         )
         result = npf.ppmt(*args) if when is None else npf.ppmt(*args, when)
         assert_decimal_close(
             result,
-            Decimal('-204.145914'),  # Computed using Google Sheet's PPMT
+            Decimal("-204.145914"),  # Computed using Google Sheet's PPMT
             tol=1e-5,
         )
 
-    @pytest.mark.parametrize('args', [
-        (0.1 / 12, 0, 60, 15000),
-        (Decimal('0.012'), Decimal('0'), Decimal('60'), Decimal('15000'))
-    ])
+    @pytest.mark.parametrize(
+        "args",
+        [
+            (0.1 / 12, 0, 60, 15000),
+            (Decimal("0.012"), Decimal("0"), Decimal("60"), Decimal("15000")),
+        ],
+    )
     def test_invalid_per(self, args):
         # Note that math.isnan() handles Decimal NaN correctly.
         assert math.isnan(npf.ppmt(*args))
 
-    @pytest.mark.parametrize('when, desired', [
-        (
-            None,
-            [-75.62318601, -76.25337923, -76.88882405, -77.52956425],
-        ), (
-            [0, 1, 'end', 'begin'],
-            [-75.62318601, -75.62318601, -76.88882405, -76.88882405],
-        )
-    ])
+    @pytest.mark.parametrize(
+        "when, desired",
+        [
+            (
+                None,
+                [-75.62318601, -76.25337923, -76.88882405, -77.52956425],
+            ),
+            (
+                [0, 1, "end", "begin"],
+                [-75.62318601, -75.62318601, -76.88882405, -76.88882405],
+            ),
+        ],
+    )
     def test_broadcast(self, when, desired):
         args = (0.1 / 12, numpy.arange(1, 5), 24, 2000, 0)
         result = npf.ppmt(*args) if when is None else npf.ppmt(*args, when)
         assert_allclose(result, desired, rtol=1e-5)
 
-    @pytest.mark.parametrize('when, desired', [
-        (
-            None,
-            [
-                Decimal('-75.62318601'),
-                Decimal('-76.25337923'),
-                Decimal('-76.88882405'),
-                Decimal('-77.52956425')
-            ],
-        ), (
-            [Decimal('0'), Decimal('1'), 'end', 'begin'],
-            [
-                Decimal('-75.62318601'),
-                Decimal('-75.62318601'),
-                Decimal('-76.88882405'),
-                Decimal('-76.88882405')
-            ]
-        )
-    ])
+    @pytest.mark.parametrize(
+        "when, desired",
+        [
+            (
+                None,
+                [
+                    Decimal("-75.62318601"),
+                    Decimal("-76.25337923"),
+                    Decimal("-76.88882405"),
+                    Decimal("-77.52956425"),
+                ],
+            ),
+            (
+                [Decimal("0"), Decimal("1"), "end", "begin"],
+                [
+                    Decimal("-75.62318601"),
+                    Decimal("-75.62318601"),
+                    Decimal("-76.88882405"),
+                    Decimal("-76.88882405"),
+                ],
+            ),
+        ],
+    )
     def test_broadcast_decimal(self, when, desired):
         args = (
-            Decimal('0.1') / Decimal('12'),
+            Decimal("0.1") / Decimal("12"),
             numpy.arange(1, 5),
-            Decimal('24'),
-            Decimal('2000'),
-            Decimal('0')
+            Decimal("24"),
+            Decimal("2000"),
+            Decimal("0"),
         )
         result = npf.ppmt(*args) if when is None else npf.ppmt(*args, when)
         assert_decimal_close(result, desired, tol=1e-8)
@@ -468,14 +587,14 @@ class TestIpmt:
         )
 
     def test_decimal(self):
-        result = npf.ipmt(Decimal('0.1') / Decimal('12'), 1, 24, 2000)
-        assert result == Decimal('-16.66666666666666666666666667')
+        result = npf.ipmt(Decimal("0.1") / Decimal("12"), 1, 24, 2000)
+        assert result == Decimal("-16.66666666666666666666666667")
 
-    @pytest.mark.parametrize('when', [1, 'begin'])
+    @pytest.mark.parametrize("when", [1, "begin"])
     def test_when_is_begin(self, when):
         assert npf.ipmt(0.1 / 12, 1, 24, 2000, 0, when) == 0
 
-    @pytest.mark.parametrize('when', [None, 0, 'end'])
+    @pytest.mark.parametrize("when", [None, 0, "end"])
     def test_when_is_end(self, when):
         if when is None:
             result = npf.ipmt(0.1 / 12, 1, 24, 2000)
@@ -483,38 +602,41 @@ class TestIpmt:
             result = npf.ipmt(0.1 / 12, 1, 24, 2000, 0, when)
         assert_allclose(result, -16.666667, rtol=1e-6)
 
-    @pytest.mark.parametrize('when', [Decimal('1'), 'begin'])
+    @pytest.mark.parametrize("when", [Decimal("1"), "begin"])
     def test_when_is_begin_decimal(self, when):
         result = npf.ipmt(
-            Decimal('0.1') / Decimal('12'),
-            Decimal('1'),
-            Decimal('24'),
-            Decimal('2000'),
-            Decimal('0'),
+            Decimal("0.1") / Decimal("12"),
+            Decimal("1"),
+            Decimal("24"),
+            Decimal("2000"),
+            Decimal("0"),
             when,
         )
         assert result == 0
 
-    @pytest.mark.parametrize('when', [None, Decimal('0'), 'end'])
+    @pytest.mark.parametrize("when", [None, Decimal("0"), "end"])
     def test_when_is_end_decimal(self, when):
         # Computed using Google Sheet's IPMT
-        desired = Decimal('-16.666667')
+        desired = Decimal("-16.666667")
         args = (
-            Decimal('0.1') / Decimal('12'),
-            Decimal('1'),
-            Decimal('24'),
-            Decimal('2000'),
-            Decimal('0')
+            Decimal("0.1") / Decimal("12"),
+            Decimal("1"),
+            Decimal("24"),
+            Decimal("2000"),
+            Decimal("0"),
         )
         result = npf.ipmt(*args) if when is None else npf.ipmt(*args, when)
         assert_decimal_close(result, desired, tol=1e-5)
 
-    @pytest.mark.parametrize('per, desired', [
-        (0, numpy.nan),
-        (1, 0),
-        (2, -594.107158),
-        (3, -592.971592),
-    ])
+    @pytest.mark.parametrize(
+        "per, desired",
+        [
+            (0, numpy.nan),
+            (1, 0),
+            (2, -594.107158),
+            (3, -592.971592),
+        ],
+    )
     def test_gh_17(self, per, desired):
         # All desired results computed using Google Sheet's IPMT
         rate = 0.001988079518355057
@@ -525,13 +647,7 @@ class TestIpmt:
             assert_allclose(result, desired, rtol=1e-6)
 
     def test_broadcasting(self):
-        desired = [
-            numpy.nan,
-            -16.66666667,
-            -16.03647345,
-            -15.40102862,
-            -14.76028842
-        ]
+        desired = [numpy.nan, -16.66666667, -16.03647345, -15.40102862, -14.76028842]
         assert_allclose(
             npf.ipmt(0.1 / 12, numpy.arange(5), 24, 2000),
             desired,
@@ -540,16 +656,16 @@ class TestIpmt:
 
     def test_decimal_broadcasting(self):
         desired = [
-            Decimal('-16.66666667'),
-            Decimal('-16.03647345'),
-            Decimal('-15.40102862'),
-            Decimal('-14.76028842')
+            Decimal("-16.66666667"),
+            Decimal("-16.03647345"),
+            Decimal("-15.40102862"),
+            Decimal("-14.76028842"),
         ]
         result = npf.ipmt(
-            Decimal('0.1') / Decimal('12'),
+            Decimal("0.1") / Decimal("12"),
             list(range(1, 5)),
-            Decimal('24'),
-            Decimal('2000')
+            Decimal("24"),
+            Decimal("2000"),
         )
         assert_decimal_close(result, desired, tol=1e-4)
 
@@ -572,12 +688,12 @@ class TestFv:
 
     def test_decimal(self):
         assert_decimal_close(
-            npf.fv(Decimal('0.075'), Decimal('20'), Decimal('-2000'), 0, 0),
-            Decimal('86609.36267304300040536731624'),
+            npf.fv(Decimal("0.075"), Decimal("20"), Decimal("-2000"), 0, 0),
+            Decimal("86609.36267304300040536731624"),
             tol=1e-10,
         )
 
-    @pytest.mark.parametrize('when', [1, 'begin'])
+    @pytest.mark.parametrize("when", [1, "begin"])
     def test_when_is_begin_float(self, when):
         assert_allclose(
             npf.fv(0.075, 20, -2000, 0, when),
@@ -585,18 +701,18 @@ class TestFv:
             rtol=1e-10,
         )
 
-    @pytest.mark.parametrize('when', [Decimal('1'), 'begin'])
+    @pytest.mark.parametrize("when", [Decimal("1"), "begin"])
     def test_when_is_begin_decimal(self, when):
         result = npf.fv(
-            Decimal('0.075'),
-            Decimal('20'),
-            Decimal('-2000'),
-            Decimal('0'),
+            Decimal("0.075"),
+            Decimal("20"),
+            Decimal("-2000"),
+            Decimal("0"),
             when,
         )
-        assert_decimal_close(result, Decimal('93105.064874'), tol=1e-5)
+        assert_decimal_close(result, Decimal("93105.064874"), tol=1e-5)
 
-    @pytest.mark.parametrize('when', [None, 0, 'end'])
+    @pytest.mark.parametrize("when", [None, 0, "end"])
     def test_when_is_end_float(self, when):
         args = (0.075, 20, -2000, 0)
         result = npf.fv(*args) if when is None else npf.fv(*args, when)
@@ -606,22 +722,21 @@ class TestFv:
             rtol=1e-10,
         )
 
-    @pytest.mark.parametrize('when', [None, Decimal('0'), 'end'])
+    @pytest.mark.parametrize("when", [None, Decimal("0"), "end"])
     def test_when_is_end_decimal(self, when):
         args = (
-            Decimal('0.075'),
-            Decimal('20'),
-            Decimal('-2000'),
-            Decimal('0'),
+            Decimal("0.075"),
+            Decimal("20"),
+            Decimal("-2000"),
+            Decimal("0"),
         )
         result = npf.fv(*args) if when is None else npf.fv(*args, when)
-        assert_decimal_close(result, Decimal('86609.362673'), tol=1e-5)
+        assert_decimal_close(result, Decimal("86609.362673"), tol=1e-5)
 
     def test_broadcast(self):
         result = npf.fv([[0.1], [0.2]], 5, 100, 0, [0, 1])
         # All values computed using Google Sheet's FV
-        desired = [[-610.510000, -671.561000],
-                   [-744.160000, -892.992000]]
+        desired = [[-610.510000, -671.561000], [-744.160000, -892.992000]]
         assert_allclose(result, desired, rtol=1e-10)
 
     def test_some_rates_zero(self):
@@ -634,7 +749,6 @@ class TestFv:
 
 
 class TestIrr:
-
     def test_npv_irr_congruence(self):
         # IRR is defined as the rate required for the present value of
         # a series of cashflows to be zero, so we should have
@@ -648,14 +762,17 @@ class TestIrr:
             rtol=0,
         )
 
-    @pytest.mark.parametrize('v, desired', [
-        ([-150000, 15000, 25000, 35000, 45000, 60000], 0.0524),
-        ([-100, 0, 0, 74], -0.0955),
-        ([-100, 39, 59, 55, 20], 0.28095),
-        ([-100, 100, 0, -7], -0.0833),
-        ([-100, 100, 0, 7], 0.06206),
-        ([-5, 10.5, 1, -8, 1], 0.0886),
-    ])
+    @pytest.mark.parametrize(
+        "v, desired",
+        [
+            ([-150000, 15000, 25000, 35000, 45000, 60000], 0.0524),
+            ([-100, 0, 0, 74], -0.0955),
+            ([-100, 39, 59, 55, 20], 0.28095),
+            ([-100, 100, 0, -7], -0.0833),
+            ([-100, 100, 0, 7], 0.06206),
+            ([-5, 10.5, 1, -8, 1], 0.0886),
+        ],
+    )
     def test_basic_values(self, v, desired):
         assert_allclose(npf.irr(v), desired, atol=1e-2)
 
@@ -666,10 +783,13 @@ class TestIrr:
             atol=1e-2,
         )
 
-    @pytest.mark.parametrize('v', [
-        (1, 2, 3),
-        (-1, -2, -3),
-    ])
+    @pytest.mark.parametrize(
+        "v",
+        [
+            (1, 2, 3),
+            (-1, -2, -3),
+        ],
+    )
     def test_numpy_gh_6744(self, v):
         # Test that if there is no solution then npf.irr returns nan.
         assert numpy.isnan(npf.irr(v))
@@ -715,16 +835,37 @@ class TestIrr:
         assert_allclose(result, desired, rtol=1e-9)
 
     def test_gh_39(self):
-        cashflows = numpy.array([
-            -217500.0, -217500.0, 108466.80462450592, 101129.96439328062,
-            93793.12416205535, 86456.28393083003, 79119.44369960476,
-            71782.60346837944, 64445.76323715414, 57108.92300592884,
-            49772.08277470355, 42435.24254347826, 35098.40231225296,
-            27761.56208102766, 20424.721849802358, 13087.88161857707,
-            5751.041387351768, -1585.7988438735192, -8922.639075098821,
-            -16259.479306324123, -23596.31953754941, -30933.159768774713,
-            -38270.0, -45606.8402312253, -52943.680462450604,
-            -60280.520693675906, -67617.36092490121])
+        cashflows = numpy.array(
+            [
+                -217500.0,
+                -217500.0,
+                108466.80462450592,
+                101129.96439328062,
+                93793.12416205535,
+                86456.28393083003,
+                79119.44369960476,
+                71782.60346837944,
+                64445.76323715414,
+                57108.92300592884,
+                49772.08277470355,
+                42435.24254347826,
+                35098.40231225296,
+                27761.56208102766,
+                20424.721849802358,
+                13087.88161857707,
+                5751.041387351768,
+                -1585.7988438735192,
+                -8922.639075098821,
+                -16259.479306324123,
+                -23596.31953754941,
+                -30933.159768774713,
+                -38270.0,
+                -45606.8402312253,
+                -52943.680462450604,
+                -60280.520693675906,
+                -67617.36092490121,
+            ]
+        )
         assert_allclose(npf.irr(cashflows), 0.12, atol=1e-7)
 
     def test_gh_44(self):
@@ -749,4 +890,3 @@ class TestIrr:
 
         with pytest.raises(npf.IterationsExceededError):
             npf.irr(cashflows, maxiter=1, raise_exceptions=True)
-            

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -8,13 +8,20 @@ import pytest
 from numpy.testing import (
     assert_,
     assert_allclose,
-    assert_almost_equal,
     assert_equal,
     assert_raises,
 )
 
 import numpy_financial as npf
 
+def assert_decimal_close(actual, expected, tol=Decimal('1e-7')):
+    # Check if both actual and expected are iterable (like arrays)
+    if hasattr(actual, '__iter__') and hasattr(expected, '__iter__'):
+        for a, e in zip(actual, expected):
+            assert abs(a - e) <= tol
+    else:
+        # For single value comparisons
+        assert abs(actual - expected) <= tol
 
 class TestFinancial(object):
     def test_when(self):
@@ -287,7 +294,7 @@ class TestMirr:
         )
 
         if expected is not numpy.nan:
-            assert_almost_equal(result, number_type(expected), 15) #np.infinite()
+            assert_decimal_close(result, number_type(expected), 1e-15) #np.infinite()
         else:
             assert numpy.isnan(result)
 
@@ -377,10 +384,10 @@ class TestPpmt:
             Decimal('0'),
             when
         )
-        assert_almost_equal(
+        assert_decimal_close(
             result,
             Decimal('-302.131703'),  # Computed using Google Sheet's PPMT
-            decimal=5,
+            tol=1e-5,
         )
 
     @pytest.mark.parametrize('when', [None, Decimal('0'), 'end'])
@@ -393,10 +400,10 @@ class TestPpmt:
             Decimal('0')
         )
         result = npf.ppmt(*args) if when is None else npf.ppmt(*args, when)
-        assert_almost_equal(
+        assert_decimal_close(
             result,
             Decimal('-204.145914'),  # Computed using Google Sheet's PPMT
-            decimal=5,
+            tol=1e-5,
         )
 
     @pytest.mark.parametrize('args', [
@@ -449,7 +456,7 @@ class TestPpmt:
             Decimal('0')
         )
         result = npf.ppmt(*args) if when is None else npf.ppmt(*args, when)
-        assert_almost_equal(result, desired, decimal=8)
+        assert_decimal_close(result, desired, tol=1e-8)
 
 
 class TestIpmt:
@@ -500,7 +507,7 @@ class TestIpmt:
             Decimal('0')
         )
         result = npf.ipmt(*args) if when is None else npf.ipmt(*args, when)
-        assert_almost_equal(result, desired, decimal=5)
+        assert_decimal_close(result, desired, tol=1e-5)
 
     @pytest.mark.parametrize('per, desired', [
         (0, numpy.nan),
@@ -544,7 +551,7 @@ class TestIpmt:
             Decimal('24'),
             Decimal('2000')
         )
-        assert_almost_equal(result, desired, decimal=4)
+        assert_decimal_close(result, desired, tol=1e-4)
 
     def test_0d_inputs(self):
         args = (0.1 / 12, 1, 24, 2000)
@@ -564,10 +571,10 @@ class TestFv:
         )
 
     def test_decimal(self):
-        assert_almost_equal(
+        assert_decimal_close(
             npf.fv(Decimal('0.075'), Decimal('20'), Decimal('-2000'), 0, 0),
             Decimal('86609.36267304300040536731624'),
-            decimal=10,
+            tol=1e-10,
         )
 
     @pytest.mark.parametrize('when', [1, 'begin'])
@@ -587,7 +594,7 @@ class TestFv:
             Decimal('0'),
             when,
         )
-        assert_almost_equal(result, Decimal('93105.064874'), decimal=5)
+        assert_decimal_close(result, Decimal('93105.064874'), tol=1e-5)
 
     @pytest.mark.parametrize('when', [None, 0, 'end'])
     def test_when_is_end_float(self, when):
@@ -608,7 +615,7 @@ class TestFv:
             Decimal('0'),
         )
         result = npf.fv(*args) if when is None else npf.fv(*args, when)
-        assert_almost_equal(result, Decimal('86609.362673'), decimal=5)
+        assert_decimal_close(result, Decimal('86609.362673'), tol=1e-5)
 
     def test_broadcast(self):
         result = npf.fv([[0.1], [0.2]], 5, 100, 0, [0, 1])

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -890,3 +890,4 @@ class TestIrr:
 
         with pytest.raises(npf.IterationsExceededError):
             npf.irr(cashflows, maxiter=1, raise_exceptions=True)
+            

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -91,7 +91,7 @@ class TestFinancial(object):
 
 class TestPV:
     def test_pv(self):
-        assert_almost_equal(npf.pv(0.07, 20, 12000, 0), -127128.17, 2)
+        assert_allclose(npf.pv(0.07, 20, 12000, 0), -127128.17, atol=1e-2)
 
     def test_pv_decimal(self):
         assert_equal(npf.pv(Decimal('0.07'), Decimal('20'), Decimal('12000'),
@@ -101,7 +101,7 @@ class TestPV:
 
 class TestRate:
     def test_rate(self):
-        assert_almost_equal(npf.rate(10, 0, -3500, 10000), 0.1107, 4)
+        assert_allclose(npf.rate(10, 0, -3500, 10000), 0.1107, atol=1e-4)
 
     @pytest.mark.parametrize('number_type', [Decimal, float])
     @pytest.mark.parametrize('when', [0, 1, 'end', 'begin'])
@@ -163,9 +163,9 @@ class TestRate:
 
 class TestNpv:
     def test_npv(self):
-        assert_almost_equal(
+        assert_allclose(
             npf.npv(0.05, [-15000, 1500, 2500, 3500, 4500, 6000]),
-            122.89, 2)
+            122.89, atol=1e-2)
 
     def test_npv_decimal(self):
         assert_equal(
@@ -249,7 +249,8 @@ class TestMirr:
 
         if expected:
             decimal_part_len = len(str(expected).split('.')[1])
-            assert_almost_equal(result, expected, decimal_part_len)
+            atol_value = 10 ** -decimal_part_len
+            assert_allclose(result, expected, atol=atol_value)
         else:
             assert_(numpy.isnan(result))
 
@@ -286,7 +287,7 @@ class TestMirr:
         )
 
         if expected is not numpy.nan:
-            assert_almost_equal(result, number_type(expected), 15)
+            assert_almost_equal(result, number_type(expected), 15) #np.infinite()
         else:
             assert numpy.isnan(result)
 
@@ -324,8 +325,8 @@ class TestNper:
         assert_(npf.nper(0, -100, 1000) == 10)
 
     def test_broadcast(self):
-        assert_almost_equal(npf.nper(0.075, -2000, 0, 100000., [0, 1]),
-                            [21.5449442, 20.76156441], 4)
+        assert_allclose(npf.nper(0.075, -2000, 0, 100000., [0, 1]),
+                            [21.5449442, 20.76156441], atol=1e-4)
 
 
 class TestPpmt:
@@ -649,13 +650,13 @@ class TestIrr:
         ([-5, 10.5, 1, -8, 1], 0.0886),
     ])
     def test_basic_values(self, v, desired):
-        assert_almost_equal(npf.irr(v), desired, decimal=2)
+        assert_allclose(npf.irr(v), desired, atol=1e-2)
 
     def test_trailing_zeros(self):
-        assert_almost_equal(
+        assert_allclose(
             npf.irr([-5, 10.5, 1, -8, 1, 0, 0, 0]),
             0.0886,
-            decimal=2,
+            atol=1e-2,
         )
 
     @pytest.mark.parametrize('v', [
@@ -717,12 +718,12 @@ class TestIrr:
             -16259.479306324123, -23596.31953754941, -30933.159768774713,
             -38270.0, -45606.8402312253, -52943.680462450604,
             -60280.520693675906, -67617.36092490121])
-        assert_almost_equal(npf.irr(cashflows), 0.12)
+        assert_allclose(npf.irr(cashflows), 0.12, atol=1e-7)
 
     def test_gh_44(self):
         # "true" value as calculated by Google sheets
         cf = [-1678.87, 771.96, 1814.05, 3520.30, 3552.95, 3584.99, 4789.91, -1]
-        assert_almost_equal(npf.irr(cf), 1.00426, 4)
+        assert_allclose(npf.irr(cf), 1.00426, atol=1e-4)
 
     def test_irr_no_real_solution_exception(self):
         # Test that if there is no solution because all the cashflows

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -6,10 +6,10 @@ from decimal import Decimal
 import numpy
 import pytest
 from numpy.testing import (
-    assert_,
     assert_allclose,
     assert_equal,
     assert_raises,
+    assert_,
 )
 
 import numpy_financial as npf
@@ -749,3 +749,4 @@ class TestIrr:
 
         with pytest.raises(npf.IterationsExceededError):
             npf.irr(cashflows, maxiter=1, raise_exceptions=True)
+            


### PR DESCRIPTION
#66 Fixed the issue
Changed assert_almost_equals to assert_allclose and a custom function(assert_decimal_close).
Had to create assert_decimal_close, which finds the absolute difference in values and compares it to a tolerance level.
Cannot use the `assert_allclose` because it uses isfinite under the covers which does not support the Decimal type.
See issue: https://github.com/numpy/numpy/issues/9954

 