### PR TITLE
ENH: NPV: Support calculation for vectors of rates and cashflows

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 import numpy as np
+
 import numpy_financial as npf
 
 
@@ -31,15 +32,15 @@ class Npv2D:
         npf.npv(self.rates, self.cashflows)
 
     def time_for_loop(self, n_cashflows, cashflow_lengths, rates_lengths):
-        for i, rate in enumerate(self.rates):
-            for j, cashflow in enumerate(self.cashflows):
+        for rate in self.rates:
+            for cashflow in self.cashflows:
                 npf.npv(rate, cashflow)
 
     def time_broadcast_decimal(self, n_cashflows, cashflow_lengths, rates_lengths):
         npf.npv(self.rates_decimal, self.cashflows_decimal)
 
     def time_for_loop_decimal(self, n_cashflows, cashflow_lengths, rates_lengths):
-        for i, rate in enumerate(self.rates_decimal):
-            for j, cashflow in enumerate(self.cashflows_decimal):
+        for rate in self.rates_decimal:
+            for cashflow in self.cashflows_decimal:
                 npf.npv(rate, cashflow)
 

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,40 +1,45 @@
-import numpy as np
+from decimal import Decimal
 
+import numpy as np
 import numpy_financial as npf
 
 
-class Npv1DCashflow:
+class Npv2D:
 
-    param_names = ["cashflow_length"]
+    param_names = ["n_cashflows", "cashflow_lengths", "rates_lengths"]
     params = [
         (1, 10, 100, 1000),
-    ]
-
-    def __init__(self):
-        self.cashflows = None
-
-    def setup(self, cashflow_length):
-        rng = np.random.default_rng(0)
-        self.cashflows = rng.standard_normal(cashflow_length)
-
-    def time_1d_cashflow(self, cashflow_length):
-        npf.npv(0.08, self.cashflows)
-
-
-class Npv2DCashflows:
-
-    param_names = ["n_cashflows", "cashflow_lengths"]
-    params = [
         (1, 10, 100, 1000),
         (1, 10, 100, 1000),
     ]
 
     def __init__(self):
+        self.rates_decimal = None
+        self.rates = None
+        self.cashflows_decimal = None
         self.cashflows = None
 
-    def setup(self, n_cashflows, cashflow_lengths):
+    def setup(self, n_cashflows, cashflow_lengths, rates_lengths):
         rng = np.random.default_rng(0)
-        self.cashflows = rng.standard_normal((n_cashflows, cashflow_lengths))
+        cf_shape = (n_cashflows, cashflow_lengths)
+        self.cashflows = rng.standard_normal(cf_shape)
+        self.rates = rng.standard_normal(rates_lengths)
+        self.cashflows_decimal = rng.standard_normal(cf_shape).asdtype(Decimal)
+        self.rates_decimal = rng.standard_normal(rates_lengths).asdtype(Decimal)
 
-    def time_2d_cashflow(self, n_cashflows, cashflow_lengths):
-        npf.npv(0.08, self.cashflows)
+    def time_broadcast(self, n_cashflows, cashflow_lengths, rates_lengths):
+        npf.npv(self.rates, self.cashflows)
+
+    def time_for_loop(self, n_cashflows, cashflow_lengths, rates_lengths):
+        for i, rate in enumerate(self.rates):
+            for j, cashflow in enumerate(self.cashflows):
+                npf.npv(rate, cashflow)
+
+    def time_broadcast_decimal(self, n_cashflows, cashflow_lengths, rates_lengths):
+        npf.npv(self.rates_decimal, self.cashflows_decimal)
+
+    def time_for_loop_decimal(self, n_cashflows, cashflow_lengths, rates_lengths):
+        for i, rate in enumerate(self.rates_decimal):
+            for j, cashflow in enumerate(self.cashflows_decimal):
+                npf.npv(rate, cashflow)
+

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -5,6 +5,15 @@ import numpy as np
 import numpy_financial as npf
 
 
+def _to_decimal_array_1d(array):
+    return np.array([Decimal(x) for x in array.tolist()])
+
+
+def _to_decimal_array_2d(array):
+    decimals = [Decimal(x) for row in array.tolist() for x in row]
+    return np.array(decimals).reshape(array.shape)
+
+
 class Npv2D:
 
     param_names = ["n_cashflows", "cashflow_lengths", "rates_lengths"]
@@ -25,8 +34,8 @@ class Npv2D:
         cf_shape = (n_cashflows, cashflow_lengths)
         self.cashflows = rng.standard_normal(cf_shape)
         self.rates = rng.standard_normal(rates_lengths)
-        self.cashflows_decimal = rng.standard_normal(cf_shape).astype(Decimal)
-        self.rates_decimal = rng.standard_normal(rates_lengths).astype(Decimal)
+        self.cashflows_decimal = _to_decimal_array_2d(self.cashflows)
+        self.rates_decimal = _to_decimal_array_1d(self.rates)
 
     def time_broadcast(self, n_cashflows, cashflow_lengths, rates_lengths):
         npf.npv(self.rates, self.cashflows)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -8,9 +8,9 @@ class Npv2D:
 
     param_names = ["n_cashflows", "cashflow_lengths", "rates_lengths"]
     params = [
-        (1, 10, 100, 1000),
-        (1, 10, 100, 1000),
-        (1, 10, 100, 1000),
+        (1, 10, 100),
+        (1, 10, 100),
+        (1, 10, 100),
     ]
 
     def __init__(self):

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -24,8 +24,8 @@ class Npv2D:
         cf_shape = (n_cashflows, cashflow_lengths)
         self.cashflows = rng.standard_normal(cf_shape)
         self.rates = rng.standard_normal(rates_lengths)
-        self.cashflows_decimal = rng.standard_normal(cf_shape).asdtype(Decimal)
-        self.rates_decimal = rng.standard_normal(rates_lengths).asdtype(Decimal)
+        self.cashflows_decimal = rng.standard_normal(cf_shape).astype(Decimal)
+        self.rates_decimal = rng.standard_normal(rates_lengths).astype(Decimal)
 
     def time_broadcast(self, n_cashflows, cashflow_lengths, rates_lengths):
         npf.npv(self.rates, self.cashflows)

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -955,6 +955,20 @@ def npv(rate, values):
            [-2798.19, -3612.24],
            [-2884.3 , -3710.74]])
 
+    The NPV calculation also supports `decimal.Decimal` types, for example
+    if using Decimal ``rates``:
+
+    >>> rates = [Decimal("0.00"), Decimal("0.05"), Decimal("0.10")]
+    >>> cashflows = [[-4_000, 500, 800], [-5_000, 600, 900]]
+    >>> npf.npv(rates, cashflows)
+    array([[Decimal('-2700.0'), Decimal('-3500.0')],
+           [Decimal('-2798.185941043083900226757370'),
+            Decimal('-3612.244897959183673469387756')],
+           [Decimal('-2884.297520661157024793388430'),
+            Decimal('-3710.743801652892561983471074')]], dtype=object)
+
+    This also works for Decimal cashflows.
+
     """
     rates = np.atleast_1d(rate)
     values = np.atleast_2d(values)

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -862,6 +862,7 @@ def _npv_native(rates, values, out, zero, one):
             out[i, j] = acc
 
 
+# We require ``forceobj=True`` here to support decimal.Decimal types
 @nb.jit(forceobj=True)
 def _npv_decimal(rates, values, out, zero, one):
     for i in range(rates.shape[0]):
@@ -937,6 +938,17 @@ def npv(rate, values):
     >>> cashflows[0] = 0
     >>> np.round(npf.npv(rate, cashflows) + initial_cashflow, 5)
     3065.22267
+
+    The NPV calculation may be applied to several ``rates`` and ``cashflows``
+    simulatneously. This produces an array of shape
+    ``(len(rates), len(cashflows))``.
+
+    >>> rates = [0.00, 0.05, 0.10]
+    >>> cashflows = [[-4_000, 500, 800], [-5_000, 600, 900]]
+    >>> npf.npv(rates, cashflows).round(2)
+    array([[-2700.  , -3500.  ],
+           [-2798.19, -3612.24],
+           [-2884.3 , -3710.74]])
 
     """
     rates = np.atleast_1d(rate)

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -852,10 +852,10 @@ def irr(values, *, guess=None, tol=1e-12, maxiter=100, raise_exceptions=False):
     return np.nan
 
 
-@nb.njit
+@nb.njit(parallel=True)
 def _npv_native(rates, values, out, zero, one):
-    for i in range(rates.shape[0]):
-        for j in range(values.shape[0]):
+    for i in nb.prange(rates.shape[0]):
+        for j in nb.prange(values.shape[0]):
             acc = zero
             for t in range(values.shape[1]):
                 acc += values[j, t] / ((one + rates[i]) ** t)

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -63,6 +63,15 @@ def _use_decimal_dtype(*arrays):
     return any(_is_object_array(array) for array in arrays)
 
 
+def _to_decimal_array_1d(array):
+    return np.array([Decimal(x) for x in array.tolist()])
+
+
+def _to_decimal_array_2d(array):
+    decimals = [Decimal(x) for row in array.tolist() for x in row]
+    return np.array(decimals).reshape(array.shape)
+
+
 def fv(rate, nper, pmt, pv, when='end'):
     """Compute the future value.
 
@@ -840,15 +849,6 @@ def irr(values, *, guess=None, tol=1e-12, maxiter=100, raise_exceptions=False):
         raise IterationsExceededError('Maximum number of iterations exceeded.')
 
     return np.nan
-
-
-def _to_decimal_array_1d(array):
-    return np.array([Decimal(x) for x in array.tolist()])
-
-
-def _to_decimal_array_2d(array):
-    l = [Decimal(x) for row in array.tolist() for x in row]
-    return np.array(l).reshape(array.shape)
 
 
 def npv(rate, values):

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -857,23 +857,23 @@ def irr(values, *, guess=None, tol=1e-12, maxiter=100, raise_exceptions=False):
 
 
 @nb.njit(parallel=True)
-def _npv_native(rates, values, out, zero, one):
+def _npv_native(rates, values, out):
     for i in nb.prange(rates.shape[0]):
         for j in nb.prange(values.shape[0]):
-            acc = zero
+            acc = 0.0
             for t in range(values.shape[1]):
-                acc += values[j, t] / ((one + rates[i]) ** t)
+                acc += values[j, t] / ((1.0 + rates[i]) ** t)
             out[i, j] = acc
 
 
 # We require ``forceobj=True`` here to support decimal.Decimal types
 @nb.jit(forceobj=True)
-def _npv_decimal(rates, values, out, zero, one):
+def _npv_decimal(rates, values, out):
     for i in range(rates.shape[0]):
         for j in range(values.shape[0]):
-            acc = zero
+            acc = Decimal("0.0")
             for t in range(values.shape[1]):
-                acc += values[j, t] / ((one + rates[i]) ** t)
+                acc += values[j, t] / ((Decimal("1.0") + rates[i]) ** t)
             out[i, j] = acc
 
 
@@ -972,16 +972,14 @@ def npv(rate, values):
     if dtype == Decimal:
         rates = _to_decimal_array_1d(rates)
         values = _to_decimal_array_2d(values)
-    zero = dtype("0.0")
-    one = dtype("1.0")
 
     shape = _get_output_array_shape(rates, values)
     out = np.empty(shape=shape, dtype=dtype)
 
     if dtype == Decimal:
-        _npv_decimal(rates, values, out, zero, one)
+        _npv_decimal(rates, values, out)
     else:
-        _npv_native(rates, values, out, zero, one)
+        _npv_native(rates, values, out)
 
     return _return_ufunc_like(out)
 

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -73,6 +73,10 @@ def _to_decimal_array_2d(array):
     return np.array(decimals).reshape(array.shape)
 
 
+def _get_output_array_shape(*arrays):
+    return tuple(array.shape[0] for array in arrays)
+
+
 def fv(rate, nper, pmt, pv, when='end'):
     """Compute the future value.
 
@@ -970,7 +974,7 @@ def npv(rate, values):
     zero = dtype("0.0")
     one = dtype("1.0")
 
-    shape = tuple(array.shape[0] for array in (rates, values))
+    shape = _get_output_array_shape(rates, values)
     out = np.empty(shape=shape, dtype=dtype)
 
     if dtype == Decimal:

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -46,6 +46,23 @@ def _convert_when(when):
         return [_when_to_num[x] for x in when]
 
 
+def _return_ufunc_like(array):
+    try:
+        # If size of array is one, return scalar
+        return array.item()
+    except ValueError:
+        # Otherwise, return entire array
+        return array
+
+
+def _is_object_array(array):
+    return array.dtype == np.dtype("O")
+
+
+def _use_decimal_dtype(*arrays):
+    return any(_is_object_array(array) for array in arrays)
+
+
 def fv(rate, nper, pmt, pv, when='end'):
     """Compute the future value.
 
@@ -825,6 +842,15 @@ def irr(values, *, guess=None, tol=1e-12, maxiter=100, raise_exceptions=False):
     return np.nan
 
 
+def _to_decimal_array_1d(array):
+    return np.array([Decimal(x) for x in array.tolist()])
+
+
+def _to_decimal_array_2d(array):
+    l = [Decimal(x) for row in array.tolist() for x in row]
+    return np.array(l).reshape(array.shape)
+
+
 def npv(rate, values):
     r"""Return the NPV (Net Present Value) of a cash flow series.
 
@@ -892,15 +918,36 @@ def npv(rate, values):
     3065.22267
 
     """
+    rates = np.atleast_1d(rate)
     values = np.atleast_2d(values)
-    timestep_array = np.arange(0, values.shape[1])
-    npv = (values / (1 + rate) ** timestep_array).sum(axis=1)
-    try:
-        # If size of array is one, return scalar
-        return npv.item()
-    except ValueError:
-        # Otherwise, return entire array
-        return npv
+
+    if rates.ndim != 1:
+        msg = "invalid shape for rates. Rate must be either a scalar or 1d array"
+        raise ValueError(msg)
+
+    if values.ndim != 2:
+        msg = "invalid shape for values. Values must be either a 1d or 2d array"
+        raise ValueError(msg)
+
+    dtype = Decimal if _use_decimal_dtype(rates, values) else np.float64
+
+    if dtype == Decimal:
+        rates = _to_decimal_array_1d(rates)
+        values = _to_decimal_array_2d(values)
+    zero = dtype("0.0")
+    one = dtype("1.0")
+
+    shape = tuple(array.shape[0] for array in (rates, values))
+    out = np.empty(shape=shape, dtype=dtype)
+
+    for i in range(rates.shape[0]):
+        for j in range(values.shape[0]):
+            acc = zero
+            for t in range(values.shape[1]):
+                acc += values[j, t] / ((one + rates[i]) ** t)
+            out[i, j] = acc
+
+    return _return_ufunc_like(out)
 
 
 def mirr(values, finance_rate, reinvest_rate, *, raise_exceptions=False):

--- a/numpy_financial/_financial.py
+++ b/numpy_financial/_financial.py
@@ -882,9 +882,9 @@ def npv(rate, values):
 
     Parameters
     ----------
-    rate : scalar
+    rate : scalar or array_like shape(K, )
         The discount rate.
-    values : array_like, shape(M, )
+    values : array_like, shape(M, ) or shape(M, N)
         The values of the time series of cash flows.  The (fixed) time
         interval between cash flow "events" must be the same as that for
         which `rate` is given (i.e., if `rate` is per year, then precisely
@@ -895,9 +895,10 @@ def npv(rate, values):
 
     Returns
     -------
-    out : float
+    out : float or array shape(K, M)
         The NPV of the input cash flow series `values` at the discount
-        `rate`.
+        `rate`. `out` follows the ufunc convention of returning scalars
+        instead of single element arrays.
 
     Warnings
     --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Office/Business :: Financial :: Accounting",
@@ -38,7 +37,7 @@ classifiers = [
 packages = [{include = "numpy_financial"}]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.9,<3.12"
 numpy = "^1.23"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ packages = [{include = "numpy_financial"}]
 [tool.poetry.dependencies]
 python = "^3.9,<3.12"
 numpy = "^1.23"
+numba = "^0.58.1"
 
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
NumPy-Financial now supports calculation of NPV for vectors of rates and cashflows e.g.

```python
>>> rates = [0.00, 0.05, 0.10]
>>> cashflows = [[-4_000, 500, 800], [-5_000, 600, 900]]
>>> npf.npv(rates, cashflows)
array([[-2700.  , -3500.  ],
           [-2798.19, -3612.24],
           [-2884.3 , -3710.74]])
```

This was previously not supported. This behaviour was first implemented by naively looping through rates and values. As Python for loops are slow, numba is applied to accelerate the process. This has lead to a significant speedup, especially for native types.

There are some potential drawbacks to using numba:

* It adds another dependency to our stack
* That dependency is large (>100MB)
* numba requires a runtime step to compile
*  We need to duplicate the functions for `Decimal` support