### PR TITLE
REL: Update minimum required versions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "numpy-financial"
-version = "1.1.0.dev0"
+version = "2.0.0"
 description = "Simple financial functions"
 license = "BSD-3-Clause"
 authors = ["Travis E. Oliphant et al."]
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -38,11 +37,11 @@ classifiers = [
 packages = [{include = "numpy_financial"}]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 numpy = "^1.23"
 
 [tool.poetry.group.test.dependencies]
-pytest = "^7.4"
+pytest = "^8.0"
 
 
 [tool.poetry.group.docs.dependencies]
@@ -53,9 +52,9 @@ pydata-sphinx-theme = "^0.14.3"
 
 
 [tool.poetry.group.lint.dependencies]
-ruff = "^0.1.6"
+ruff = "^0.3"
 
 
 [tool.poetry.group.bench.dependencies]
-asv = "^0.6.1"
+asv = "^0.6"
 


### PR DESCRIPTION
This PR changes several of the minimum required dependencies. 

Most notable is the bump from Python 3.9 to 3.10 as the minimum supported version. Python 3.10 adds several new features, including typing improvements and the match statement.