### PR TITLE
MAINT: use a PEP 639 ``project.license`` SPDX expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "numpy-financial"
 version = "2.0.0"
 requires-python = ">=3.10"
 description = "Simple financial functions"
-license = {file = "LICENSE.txt"}
+license = "BSD-3-Clause"
 authors = [{name = "Travis E. Oliphant et al."}]
 maintainers = [{ name = "Numpy Financial Developers", email = "numpy-discussion@python.org" }]
 readme = "README.md"
@@ -22,7 +22,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Financial and Insurance Industry",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This resolves the following Python 3..13 build-time warning:

```
********************************************************************************
Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

By 2026-Feb-18, you need to update your project and remove deprecated calls
or your builds will no longer be supported.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```

See also

- <https://peps.python.org/pep-0639/>
- <https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license>