### PR TITLE
Add GitHub Actions CI with test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install numpy pytest pytest-cov
+      - name: Run tests with coverage
+        run: pytest tests/ -v --cov=numpy_financial --cov-report=xml
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml


### PR DESCRIPTION
This PR adds GitHub Actions CI workflow with pytest-cov for test coverage tracking. This addresses issue #58 about needing more thorough test coverage.